### PR TITLE
Removing telescope from harpoon

### DIFF
--- a/lua/plugins/harpoon.lua
+++ b/lua/plugins/harpoon.lua
@@ -1,22 +1,3 @@
-local conf = require("telescope.config").values
-local function toggle_telescope(harpoon_files)
-  local file_paths = {}
-  for _, item in ipairs(harpoon_files.items) do
-    table.insert(file_paths, item.value)
-  end
-
-  require("telescope.pickers")
-    .new({}, {
-      prompt_title = "Harpoon",
-      finder = require("telescope.finders").new_table({
-        results = file_paths,
-      }),
-      previewer = conf.file_previewer({}),
-      sorter = conf.generic_sorter({}),
-    })
-    :find()
-end
-
 return {
   {
     "ThePrimeagen/harpoon",
@@ -78,15 +59,6 @@ return {
           require("harpoon"):list():select(5)
         end,
         desc = "harpoon to file 5",
-      },
-      {
-        "<leader>bh",
-        function()
-          local harpoon = require("harpoon")
-          toggle_telescope(harpoon:list())
-        end,
-        mode = { "n" },
-        desc = "Telescope harpoon",
       },
       {
         "<leader>ha",


### PR DESCRIPTION
This pull request removes functionality related to integrating Harpoon with Telescope in the `lua/plugins/harpoon.lua` file. Specifically, it eliminates the `toggle_telescope` function and the associated keybinding for invoking Telescope with Harpoon files.

### Removal of Telescope integration with Harpoon:

* Deleted the `toggle_telescope` function, which used Telescope to display Harpoon file paths in a picker.
* Removed the `<leader>bh` keybinding that invoked the `toggle_telescope` function, along with its description ("Telescope harpoon").