### PR TITLE
Home dev

### DIFF
--- a/lua/plugins/colorscheme.lua
+++ b/lua/plugins/colorscheme.lua
@@ -283,7 +283,6 @@ return {
     opts = {
       transparent = true,
       italic_comments = true,
-      borderless_telescope = true,
       terminal_colors = true,
     },
   },

--- a/lua/plugins/file_explorer.lua
+++ b/lua/plugins/file_explorer.lua
@@ -18,13 +18,13 @@ return {
     "mikavilpas/yazi.nvim",
     keys = {
       {
-        "<leader>-",
+        "<leader>fo",
         mode = { "n", "v" },
         "<cmd>Yazi<cr>",
         desc = "Open yazi at the current file",
       },
       {
-        "<leader>cw",
+        "<leader>e",
         "<cmd>Yazi cwd<cr>",
         desc = "Open the file manager in nvim's working directory",
       },

--- a/lua/plugins/snacks.lua
+++ b/lua/plugins/snacks.lua
@@ -116,22 +116,22 @@ return {
         end,
         desc = "Notification History",
       },
-      {
-        "<leader>e",
-        function()
-          vim.opt.scrolloff = 0
-          Snacks.explorer({ auto_close = true, focus = "list" })
-        end,
-        desc = "File Explorer",
-      },
-      {
-        "<leader>fo",
-        function()
-          vim.opt.scrolloff = 0
-          Snacks.explorer.reveal({ auto_close = false, focus = "list" })
-        end,
-        desc = "File Explorer reveal",
-      },
+      -- {
+      --   "<leader>e",
+      --   function()
+      --     vim.opt.scrolloff = 0
+      --     Snacks.explorer({ auto_close = true, focus = "list" })
+      --   end,
+      --   desc = "File Explorer",
+      -- },
+      -- {
+      --   "<leader>fo",
+      --   function()
+      --     vim.opt.scrolloff = 0
+      --     Snacks.explorer.reveal({ auto_close = false, focus = "list" })
+      --   end,
+      --   desc = "File Explorer reveal",
+      -- },
       {
         "<leader>fb",
         function()


### PR DESCRIPTION
This pull request introduces changes to improve keybindings for file exploration and modify plugin configurations. The most significant updates include remapping file explorer shortcuts, deprecating redundant keybindings, and simplifying the colorscheme plugin options.

### Keybinding Updates:

* [`lua/plugins/file_explorer.lua`](diffhunk://#diff-ff27932cbe8c855ac1e01bb7c81a82b5cfac2c9cd4c7e904d86db5da9b29fe9eL21-R27): Updated file explorer keybindings. `<leader>-` was changed to `<leader>fo` for opening Yazi at the current file, and `<leader>cw` was changed to `<leader>e` for opening the file manager in the working directory.
* [`lua/plugins/snacks.lua`](diffhunk://#diff-9c18067df31f03d6d1a703f3f9f718c92c54322355ea9f3070201e2b841b71ddL119-R134): Deprecated previously defined file explorer keybindings (`<leader>e` and `<leader>fo`) by commenting them out, as they are now handled by the updated keybindings in `file_explorer.lua`.

### Plugin Configuration:

* [`lua/plugins/colorscheme.lua`](diffhunk://#diff-d0a9f68f76744a6bc938ff655b67948e91455f84f4f966626aacd70858234ef0L286): Removed the `borderless_telescope` option from the colorscheme plugin configuration to streamline settings.