### PR TITLE
Minor updates in autocmds and keymaps

### DIFF
--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -35,7 +35,7 @@ vim.api.nvim_create_autocmd("TextYankPost", {
   desc = "Hightlight selection on yank",
   pattern = "*",
   callback = function()
-    vim.highlight.on_yank({ higroup = "IncSearch", timeout = 150 })
+    vim.hl.on_yank({ higroup = "IncSearch", timeout = 150 })
   end,
 })
 
@@ -196,7 +196,7 @@ vim.api.nvim_create_autocmd("LspAttach", {
     map("gh", vim.lsp.buf.signature_help, "[g]o to signature [h]elp")
     map("<leader>ca", vim.lsp.buf.code_action, "[C]ode [A]ction")
     map("K", vim.lsp.buf.hover, "Hover Documentation")
-    vmap("<leader>Lf", vim.lsp.buf.format, "[l]sp [f]ormat")
+    vmap("<leader>bf", vim.lsp.buf.format, "[l]sp [f]ormat")
 
     local client = vim.lsp.get_client_by_id(event.data.client_id)
     assert(client, "LSP client not found")

--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -163,10 +163,6 @@ end, { desc = "Previous Colorscheme" })
 
 -- Buffer related
 
-map("n", "<leader>bf", function()
-  vim.lsp.buf.format()
-end, { desc = "Format buffer" })
-
 map("n", "<leader>bb", function()
   vim.cmd([[b#]])
 end, { desc = "Switch to previous buffer" })
@@ -383,35 +379,3 @@ wk.add({
   },
 }, { mode = "n" })
 
--- integrate fzf-lua with projects
--- from https://github.com/ahmedkhalf/project.nvim/issues/99
-map("n", "<leader>fp", function()
-  local contents = require("project_nvim").get_recent_projects()
-  local reverse = {}
-  for i = #contents, 1, -1 do
-    reverse[#reverse + 1] = contents[i]
-  end
-  local fzf = require("fzf-lua")
-  fzf.fzf_exec(reverse, {
-    actions = {
-      ["default"] = function(e)
-        -- vim.cmd.cd(e[1])
-        fzf.files({ cwd = e[1] })
-      end,
-      ["ctrl-d"] = function(x)
-        local choice = vim.fn.confirm("Delete '" .. #x .. "' projects? ", "&Yes\n&No", 2)
-        if choice == 1 then
-          local history = require("project_nvim.utils.history")
-          for _, v in ipairs(x) do
-            history.delete_project(v)
-          end
-        end
-      end,
-    },
-    prompt = "Projects> ",
-    winopts = {
-      height = 0.33,
-      width = 0.66,
-    },
-  })
-end, { silent = true, desc = "Switch project" })


### PR DESCRIPTION
This pull request includes updates to the Neovim configuration files, focusing on refactoring and improving consistency in key mappings, autocmds, and buffer-related functionality. The most important changes include renaming a key mapping for buffer formatting, updating a deprecated function call, and removing a custom integration with `fzf-lua` for project management.

### Refactoring and consistency updates:

* **Renamed buffer format key mapping**: Changed the key mapping for buffer formatting from `<leader>Lf` to `<leader>bf` for consistency with other buffer-related key mappings (`lua/config/autocmds.lua`, [[1]](diffhunk://#diff-a8a5b366c1bdddd6d1805dcf5aa6611113079809cf95b36c6b7761d991cebfafL199-R199). Removed the redundant `<leader>bf` mapping from `keymaps.lua` to avoid duplication (`lua/config/keymaps.lua`, [[2]](diffhunk://#diff-92f43ba44d4cfab6084f7614e53be9d3be8d8172e37bbe45dbda7778f01bb0aeL166-L169).

* **Updated deprecated function call**: Replaced the deprecated `vim.highlight.on_yank` function with the updated `vim.hl.on_yank` in the yank autocmd (`lua/config/autocmds.lua`, [lua/config/autocmds.luaL38-R38](diffhunk://#diff-a8a5b366c1bdddd6d1805dcf5aa6611113079809cf95b36c6b7761d991cebfafL38-R38)).

### Code cleanup:

* **Removed custom project integration**: Deleted a custom integration of `fzf-lua` with `project.nvim` for switching projects, simplifying the key mappings and reducing maintenance overhead (`lua/config/keymaps.lua`, [lua/config/keymaps.luaL386-L417](diffhunk://#diff-92f43ba44d4cfab6084f7614e53be9d3be8d8172e37bbe45dbda7778f01bb0aeL386-L417)).